### PR TITLE
fixed base urls for HereMaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - enhanced error handling for directions with Google [#15](https://github.com/gis-ops/routing-py/issues/15)
 - fixed MapboxOSRM client, removing unused parameters and unifying Isochrones interface [#21](https://github.com/gis-ops/routing-py/issues/21)
+- fixed bug that caused HereMaps client to use wrong API endpoints
+
 ### Changed
 
 - BREAKING: pulled client stuff into a separate Client class which gets passed to the individual router instances with the default being the same as before [#24](https://github.com/gis-ops/routing-py/pull/24)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - enhanced error handling for directions with Google [#15](https://github.com/gis-ops/routing-py/issues/15)
 - fixed MapboxOSRM client, removing unused parameters and unifying Isochrones interface [#21](https://github.com/gis-ops/routing-py/issues/21)
-- fixed bug that caused HereMaps client to use wrong API endpoints
-
+- fixed bug that caused HereMaps client to use wrong API endpoints [#28](https://github.com/gis-ops/routing-py/pull/28)
 ### Changed
 
 - BREAKING: pulled client stuff into a separate Client class which gets passed to the individual router instances with the default being the same as before [#24](https://github.com/gis-ops/routing-py/pull/24)

--- a/examples/compare_providers.ipynb
+++ b/examples/compare_providers.ipynb
@@ -1384,9 +1384,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "routing-py",
    "language": "python",
-   "name": "python3"
+   "name": "routing-py"
   },
   "language_info": {
    "codemirror_mode": {
@@ -1398,7 +1398,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.5"
+   "version": "3.7.3"
   },
   "toc": {
    "base_numbering": 1,

--- a/examples/compare_providers.ipynb
+++ b/examples/compare_providers.ipynb
@@ -1384,9 +1384,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "routing-py",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "routing-py"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -1398,7 +1398,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.9.5"
   },
   "toc": {
    "base_numbering": 1,

--- a/routingpy/routers/heremaps.py
+++ b/routingpy/routers/heremaps.py
@@ -28,8 +28,6 @@ from operator import itemgetter
 class HereMaps:
     """Performs requests to the HERE Maps API services."""
 
-    _base_url = ""
-
     def __init__(
         self,
         app_id=None,
@@ -99,7 +97,7 @@ class HereMaps:
             self.auth = {"app_id": self.app_id, "app_code": self.app_code}
 
         self.client = client(
-            self._base_url,
+            "",
             user_agent,
             timeout,
             retry_timeout,

--- a/routingpy/routers/heremaps.py
+++ b/routingpy/routers/heremaps.py
@@ -591,13 +591,11 @@ class HereMaps:
         :rtype: :class:`routingpy.direction.Direction` or :class:`routingpy.direction.Directions`
         """
 
-        self.base_url = (
+        self.client.base_url = (
             "https://route.api.here.com/routing/7.2"
             if self.api_key is None
             else "https://route.ls.hereapi.com/routing/7.2"
         )
-
-        self.client.base_url = self.base_url
 
         params = self.auth.copy()
 
@@ -995,13 +993,11 @@ class HereMaps:
         :rtype: dict
         """
 
-        self.base_url = (
+        self.client.base_url = (
             "https://isoline.route.api.here.com/routing/7.2"
             if self.api_key is None
             else "https://isoline.route.ls.hereapi.com/routing/7.2"
         )
-
-        self.client.base_url = self.base_url
 
         params = self.auth.copy()
 
@@ -1265,12 +1261,11 @@ class HereMaps:
         :returns: raw JSON response
         :rtype: dict
         """
-        self.base_url = (
+        self.client.base_url = (
             "https://matrix.route.api.here.com/routing/7.2"
             if self.api_key is None
             else "https://matrix.route.ls.hereapi.com/routing/7.2"
         )
-        self.client.base_url = self.base_url
 
         params = self.auth.copy()
 

--- a/routingpy/routers/heremaps.py
+++ b/routingpy/routers/heremaps.py
@@ -596,6 +596,9 @@ class HereMaps:
             if self.api_key is None
             else "https://route.ls.hereapi.com/routing/7.2"
         )
+
+        self.client.base_url = self.base_url
+
         params = self.auth.copy()
 
         locations = self._build_locations(locations)
@@ -997,6 +1000,9 @@ class HereMaps:
             if self.api_key is None
             else "https://isoline.route.ls.hereapi.com/routing/7.2"
         )
+
+        self.client.base_url = self.base_url
+
         params = self.auth.copy()
 
         params[center_type] = self._build_locations(locations)[0]
@@ -1264,6 +1270,8 @@ class HereMaps:
             if self.api_key is None
             else "https://matrix.route.ls.hereapi.com/routing/7.2"
         )
+        self.client.base_url = self.base_url
+
         params = self.auth.copy()
 
         locations = self._build_locations(locations)

--- a/routingpy/routers/heremaps.py
+++ b/routingpy/routers/heremaps.py
@@ -28,8 +28,7 @@ from operator import itemgetter
 class HereMaps:
     """Performs requests to the HERE Maps API services."""
 
-    _DEFAULT_BASE_URL = "https://route.api.here.com/routing/7.2"
-    _APIKEY_BASE_URL = "https://route.ls.hereapi.com/routing/7.2"
+    _base_url = ""
 
     def __init__(
         self,
@@ -95,14 +94,12 @@ class HereMaps:
         self.api_key = api_key
 
         if self.api_key:
-            self.base_url = self._APIKEY_BASE_URL
             self.auth = {"apikey": self.api_key}
         else:
-            self.base_url = self._DEFAULT_BASE_URL
             self.auth = {"app_id": self.app_id, "app_code": self.app_code}
 
         self.client = client(
-            self.base_url,
+            self._base_url,
             user_agent,
             timeout,
             retry_timeout,

--- a/tests/test_heremaps.py
+++ b/tests/test_heremaps.py
@@ -148,7 +148,7 @@ class HereMapsTest(_test.TestCase):
 
         responses.add(
             responses.GET,
-            "https://route.api.here.com/routing/7.2/calculateisoline.json",
+            "https://isoline.route.api.here.com/routing/7.2/calculateisoline.json",
             status=200,
             json=ENDPOINTS_RESPONSES[self.name]["isochrones"],
             content_type="application/json",
@@ -158,7 +158,7 @@ class HereMapsTest(_test.TestCase):
 
         self.assertEqual(1, len(responses.calls))
         self.assertURLEqual(
-            "https://route.api.here.com/routing/7.2/calculateisoline.json?app_code=sample_app_code&"
+            "https://isoline.route.api.here.com/routing/7.2/calculateisoline.json?app_code=sample_app_code&"
             "app_id=sample_app_id&mode=fastest%3Bcar&quality=1&range=1000%2C2000%2C3000&rangeType=distance&"
             "singleComponent=false&start=geo%2148.23424%2C8.34234",
             responses.calls[0].request.url,
@@ -178,7 +178,7 @@ class HereMapsTest(_test.TestCase):
 
         responses.add(
             responses.GET,
-            "https://route.api.here.com/routing/7.2/calculatematrix.json",
+            "https://matrix.route.api.here.com/routing/7.2/calculatematrix.json",
             status=200,
             json=ENDPOINTS_RESPONSES[self.name]["matrix"],
             content_type="application/json",
@@ -188,7 +188,7 @@ class HereMapsTest(_test.TestCase):
 
         self.assertEqual(1, len(responses.calls))
         self.assertURLEqual(
-            "https://route.api.here.com/routing/7.2/calculatematrix.json?app_code=sample_app_code&"
+            "https://matrix.route.api.here.com/routing/7.2/calculatematrix.json?app_code=sample_app_code&"
             "app_id=sample_app_id&destination0=geo%2149.445776%2C8.780916&height=20&length=10&limitedWeight=10&"
             "mode=fastest%3Bcar&shippedHazardousGoods=gas%2Cflammable&start0=geo%2149.420577%2C8.688641&"
             "start1=geo%2149.415776%2C8.680916&summaryAttributes=traveltime%2Ccostfactor&trailersCount=3&truckType=truck&"
@@ -333,7 +333,7 @@ class HereMapsKeyTest(_test.TestCase):
 
         responses.add(
             responses.GET,
-            "https://route.ls.hereapi.com/routing/7.2/calculateisoline.json",
+            "https://isoline.route.ls.hereapi.com/routing/7.2/calculateisoline.json",
             status=200,
             json=ENDPOINTS_RESPONSES[self.name]["isochrones"],
             content_type="application/json",
@@ -343,7 +343,7 @@ class HereMapsKeyTest(_test.TestCase):
 
         self.assertEqual(1, len(responses.calls))
         self.assertURLEqual(
-            "https://route.ls.hereapi.com/routing/7.2/calculateisoline.json?apikey=sample_api_key&"
+            "https://isoline.route.ls.hereapi.com/routing/7.2/calculateisoline.json?apikey=sample_api_key&"
             "mode=fastest%3Bcar&quality=1&range=1000%2C2000%2C3000&rangeType=distance&"
             "singleComponent=false&start=geo%2148.23424%2C8.34234",
             responses.calls[0].request.url,
@@ -363,7 +363,7 @@ class HereMapsKeyTest(_test.TestCase):
 
         responses.add(
             responses.GET,
-            "https://route.ls.hereapi.com/routing/7.2/calculatematrix.json",
+            "https://matrix.route.ls.hereapi.com/routing/7.2/calculatematrix.json",
             status=200,
             json=ENDPOINTS_RESPONSES[self.name]["matrix"],
             content_type="application/json",
@@ -373,7 +373,7 @@ class HereMapsKeyTest(_test.TestCase):
 
         self.assertEqual(1, len(responses.calls))
         self.assertURLEqual(
-            "https://route.ls.hereapi.com/routing/7.2/calculatematrix.json?apikey=sample_api_key&"
+            "https://matrix.route.ls.hereapi.com/routing/7.2/calculatematrix.json?apikey=sample_api_key&"
             "destination0=geo%2149.445776%2C8.780916&height=20&length=10&limitedWeight=10&"
             "mode=fastest%3Bcar&shippedHazardousGoods=gas%2Cflammable&start0=geo%2149.420577%2C8.688641&"
             "start1=geo%2149.415776%2C8.680916&summaryAttributes=traveltime%2Ccostfactor&trailersCount=3&truckType=truck&"


### PR DESCRIPTION
passes modified base urls for HereMaps' `.directions()`, `isochrones()` and `matrix()` methods to the instance's client