### PR TITLE
Fix#32

### DIFF
--- a/routingpy/isochrone.py
+++ b/routingpy/isochrone.py
@@ -64,9 +64,13 @@ class Isochrone(object):
     @property
     def geometry(self):
         """
-        The geometry of the isochrone as [[lon1, lat1], [lon2, lat2], ...] list.
+        The geometry of the isochrone as [[[lon1, lat1], [lon2, lat2], ...]] list.
 
         :rtype: list or None
+
+        .. note::
+           Since it's not known whether providers' responses adhere to OGC standards, caution is advised with regard
+           to possible orientation issues of Polygons.
         """
         return self._geometry
 

--- a/routingpy/routers/graphhopper.py
+++ b/routingpy/routers/graphhopper.py
@@ -509,7 +509,7 @@ class Graphhopper:
             isochrones.append(
                 Isochrone(
                     geometry=[
-                        l[:2] for l in polygon["geometry"]["coordinates"][0]  # noqa: E741
+                        [l[:2] for l in polygon["geometry"]["coordinates"][0]]  # noqa: E741
                     ],  # takes in elevation for some reason
                     interval=int(max_range * ((polygon["properties"]["bucket"] + 1) / buckets)),
                     center=center,

--- a/routingpy/routers/mapbox_osrm.py
+++ b/routingpy/routers/mapbox_osrm.py
@@ -430,7 +430,7 @@ class MapboxOSRM:
         return Isochrones(
             [
                 Isochrone(
-                    geometry=isochrone["geometry"]["coordinates"],
+                    geometry=[isochrone["geometry"]["coordinates"]],
                     interval=intervals[idx],
                     center=locations,
                 )

--- a/routingpy/routers/openrouteservice.py
+++ b/routingpy/routers/openrouteservice.py
@@ -475,7 +475,7 @@ class ORS:
         for idx, isochrone in enumerate(response["features"]):
             isochrones.append(
                 Isochrone(
-                    geometry=isochrone["geometry"]["coordinates"][0],
+                    geometry=isochrone["geometry"]["coordinates"],
                     interval=isochrone["properties"]["value"],
                     center=isochrone["properties"]["center"],
                 )

--- a/routingpy/routers/valhalla.py
+++ b/routingpy/routers/valhalla.py
@@ -426,7 +426,7 @@ class Valhalla:
             if feature["geometry"]["type"] in ("LineString", "Polygon"):
                 isochrones.append(
                     Isochrone(
-                        geometry=feature["geometry"]["coordinates"],
+                        geometry=[feature["geometry"]["coordinates"]],
                         interval=intervals[idx],
                         center=locations,
                     )


### PR DESCRIPTION
Since HereMaps' `isochrones()` method possibly returns multiple polygons for one isochrone, the interface is now unified so that each provider's isochrone geometry now returns a list of polygons (with mostly one feature only).