### PR TITLE
fixes #40: break out logic for collecting endpoint parameters

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
     - id: black
       language_version: python3
       # temp exlude osrm: black fails to reformat for some reason
-      args: [--check, routingpy, tests, --exclude, routingpy/routers/mapbox_osrm.py]
+      args: [routingpy, tests, --exclude, routingpy/routers/mapbox_osrm.py]
 - repo: https://gitlab.com/pycqa/flake8
   rev: 3.9.0  # pick a git hash / tag to point to
   hooks:

--- a/routingpy/convert.py
+++ b/routingpy/convert.py
@@ -18,20 +18,20 @@
 """
 
 
-def _delimit_list(arg, delimiter=","):
+def delimit_list(arg, delimiter=","):
     """Convert list to delimiter-separated string"""
-    if not _is_list(arg):
+    if not is_list(arg):
         raise TypeError("Expected a list or tuple, " "but got {}".format(type(arg).__name__))
     return delimiter.join(map(str, arg))
 
 
-def _convert_bool(boolean):
+def convert_bool(boolean):
     """Convert to stringified boolean"""
 
     return str(boolean).lower()
 
 
-def _format_float(arg):
+def format_float(arg):
     """Formats a float value to be as short as possible.
 
     Trims extraneous trailing zeros and period to give API
@@ -54,7 +54,7 @@ def _format_float(arg):
     return "{}".format(round(float(arg), 6)).rstrip("0").rstrip(".")
 
 
-def _is_list(arg):
+def is_list(arg):
     """Checks if arg is list-like."""
     if isinstance(arg, dict):
         return False

--- a/routingpy/routers/google.py
+++ b/routingpy/routers/google.py
@@ -163,7 +163,7 @@ class Google:
 
             waypoint = ""
             if self.waypoint_type == "coords":
-                waypoint += convert._delimit_list(list(reversed(self.position)))
+                waypoint += convert.delimit_list(list(reversed(self.position)))
             elif self.waypoint_type == "place_id":
                 waypoint += self.waypoint_type + ":" + self.position
             elif self.waypoint_type == "enc":
@@ -261,12 +261,12 @@ class Google:
 
         origin, destination = locations[0], locations[-1]
         if isinstance(origin, (list, tuple)):
-            params["origin"] = convert._delimit_list(list(reversed(origin)))
+            params["origin"] = convert.delimit_list(list(reversed(origin)))
         elif isinstance(origin, self.WayPoint):
             raise TypeError("The first and last locations must be list/tuple of [lon, lat]")
 
         if isinstance(destination, (list, tuple)):
-            params["destination"] = convert._delimit_list(list(reversed(destination)))
+            params["destination"] = convert.delimit_list(list(reversed(destination)))
         elif isinstance(origin, self.WayPoint):
             raise TypeError("The first and last locations must be list/tuple of [lon, lat]")
 
@@ -275,22 +275,22 @@ class Google:
             s = slice(1, -1)
             for coord in locations[s]:
                 if isinstance(coord, (list, tuple)):
-                    waypoints.append(convert._delimit_list(list(reversed(coord))))
+                    waypoints.append(convert.delimit_list(list(reversed(coord))))
                 elif isinstance(coord, self.WayPoint):
                     waypoints.append(coord.make_waypoint())
             if optimize:
                 waypoints.insert(0, "optimize:true")
 
-            params["waypoints"] = convert._delimit_list(waypoints, "|")
+            params["waypoints"] = convert.delimit_list(waypoints, "|")
 
         if self.key is not None:
             params["key"] = self.key
 
         if alternatives is not None:
-            params["alternatives"] = convert._convert_bool(alternatives)
+            params["alternatives"] = convert.convert_bool(alternatives)
 
         if avoid:
-            params["avoid"] = convert._delimit_list(avoid, "|")
+            params["avoid"] = convert.delimit_list(avoid, "|")
 
         if language:
             params["language"] = language
@@ -314,7 +314,7 @@ class Google:
             params["traffic_model"] = traffic_model
 
         if transit_mode:
-            params["transit_mode"] = convert._delimit_list(transit_mode, "|")
+            params["transit_mode"] = convert.delimit_list(transit_mode, "|")
 
         if transit_routing_preference:
             params["transit_routing_preference"] = transit_routing_preference
@@ -462,7 +462,7 @@ class Google:
         waypoints = []
         for coord in locations:
             if isinstance(coord, (list, tuple)):
-                waypoints.append(convert._delimit_list(list(reversed(coord))))
+                waypoints.append(convert.delimit_list(list(reversed(coord))))
             elif isinstance(coord, self.WayPoint):
                 waypoints.append(coord.make_waypoint())
 
@@ -471,20 +471,20 @@ class Google:
             sources_coords = itemgetter(*sources)(sources_coords)
             if not isinstance(sources_coords, (list, tuple)):
                 sources_coords = [sources_coords]
-        params["origins"] = convert._delimit_list(sources_coords, "|")
+        params["origins"] = convert.delimit_list(sources_coords, "|")
 
         destinations_coords = waypoints
         if destinations is not None:
             destinations_coords = itemgetter(*destinations)(destinations_coords)
             if not isinstance(destinations_coords, (list, tuple)):
                 destinations_coords = [destinations_coords]
-        params["destinations"] = convert._delimit_list(destinations_coords, "|")
+        params["destinations"] = convert.delimit_list(destinations_coords, "|")
 
         if self.key is not None:
             params["key"] = self.key
 
         if avoid:
-            params["avoid"] = convert._delimit_list(avoid, "|")
+            params["avoid"] = convert.delimit_list(avoid, "|")
 
         if language:
             params["language"] = language
@@ -505,7 +505,7 @@ class Google:
             params["traffic_model"] = traffic_model
 
         if transit_mode:
-            params["transit_mode"] = convert._delimit_list(transit_mode, "|")
+            params["transit_mode"] = convert.delimit_list(transit_mode, "|")
 
         if transit_routing_preference:
             params["transit_routing_preference"] = transit_routing_preference

--- a/routingpy/routers/graphhopper.py
+++ b/routingpy/routers/graphhopper.py
@@ -277,7 +277,7 @@ class Graphhopper:
         params = [("vehicle", profile)]
 
         for coordinate in locations:
-            coord_latlng = reversed([convert._format_float(f) for f in coordinate])
+            coord_latlng = reversed([convert.format_float(f) for f in coordinate])
             params.append(("point", ",".join(coord_latlng)))
 
         if self.key is not None:
@@ -287,38 +287,38 @@ class Graphhopper:
             params.append(("type", format))
 
         if optimize is not None:
-            params.append(("optimize", convert._convert_bool(optimize)))
+            params.append(("optimize", convert.convert_bool(optimize)))
 
         if instructions is not None:
-            params.append(("instructions", convert._convert_bool(instructions)))
+            params.append(("instructions", convert.convert_bool(instructions)))
 
         if locale is not None:
             params.append(("locale", locale))
 
         if elevation is not None:
-            params.append(("elevation", convert._convert_bool(elevation)))
+            params.append(("elevation", convert.convert_bool(elevation)))
 
         if points_encoded is not None:
-            params.append(("points_encoded", convert._convert_bool(points_encoded)))
+            params.append(("points_encoded", convert.convert_bool(points_encoded)))
 
         if calc_points is not None:
-            params.append(("calc_points", convert._convert_bool(calc_points)))
+            params.append(("calc_points", convert.convert_bool(calc_points)))
 
         if debug is not None:
-            params.append(("debug", convert._convert_bool(debug)))
+            params.append(("debug", convert.convert_bool(debug)))
 
         if point_hint is not None:
             for hint in point_hint:
                 params.append(("point_hint", hint))
 
         if snap_prevention:
-            params.append(("snap_prevention", convert._delimit_list(snap_prevention)))
+            params.append(("snap_prevention", convert.delimit_list(snap_prevention)))
 
         if turn_costs:
-            params.append(("turn_costs", convert._convert_bool(turn_costs)))
+            params.append(("turn_costs", convert.convert_bool(turn_costs)))
 
         if curb_side:
-            params.append(("curb_side", convert._delimit_list(curb_side)))
+            params.append(("curb_side", convert.delimit_list(curb_side)))
 
         ### all below params will only work if ch is disabled
 
@@ -326,25 +326,25 @@ class Graphhopper:
             params.extend([("details", detail) for detail in details])
 
         if ch_disable is not None:
-            params.append(("ch.disable", convert._convert_bool(ch_disable)))
+            params.append(("ch.disable", convert.convert_bool(ch_disable)))
 
         if weighting is not None:
             params.append(("weighting", weighting))
 
         if heading is not None:
-            params.append(("heading", convert._delimit_list(heading)))
+            params.append(("heading", convert.delimit_list(heading)))
 
         if heading_penalty is not None:
             params.append(("heading_penalty", heading_penalty))
 
         if pass_through is not None:
-            params.append(("pass_through", convert._convert_bool(pass_through)))
+            params.append(("pass_through", convert.convert_bool(pass_through)))
 
         if block_area is not None:
             params.append(("block_area", block_area))
 
         if avoid is not None:
-            params.append(("avoid", convert._delimit_list(avoid, ";")))
+            params.append(("avoid", convert.delimit_list(avoid, ";")))
 
         if algorithm is not None:
 
@@ -461,7 +461,7 @@ class Graphhopper:
 
         params = [("vehicle", profile), ("type", type)]
 
-        if convert._is_list(intervals):
+        if convert.is_list(intervals):
             if interval_type in (None, "time"):
                 params.append(("time_limit", intervals[0]))
             elif interval_type == "distance":
@@ -469,7 +469,7 @@ class Graphhopper:
         else:
             raise TypeError("Parameter range={} must be of type list or tuple".format(range))
 
-        center = [convert._format_float(f) for f in locations]
+        center = [convert.format_float(f) for f in locations]
         center.reverse()
         params.append(("point", ",".join(center)))
 
@@ -480,10 +480,10 @@ class Graphhopper:
             params.append(("buckets", buckets))
 
         if reverse_flow is not None:
-            params.append(("reverse_flow", convert._convert_bool(reverse_flow)))
+            params.append(("reverse_flow", convert.convert_bool(reverse_flow)))
 
         if debug is not None:
-            params.append(("debug", convert._convert_bool(debug)))
+            params.append(("debug", convert.convert_bool(debug)))
 
         return self._parse_isochrone_json(
             self.client._request("/isochrone", get_params=params, dry_run=dry_run),
@@ -566,7 +566,7 @@ class Graphhopper:
             params.append(("key", self.key))
 
         if sources is None and destinations is None:
-            locations = (reversed([convert._format_float(f) for f in coord]) for coord in locations)
+            locations = (reversed([convert.format_float(f) for f in coord]) for coord in locations)
             params.extend([("point", ",".join(coord)) for coord in locations])
 
         else:
@@ -593,11 +593,11 @@ class Graphhopper:
                 # Raised when destinations == None
                 pass
 
-            sources_out = (reversed([convert._format_float(f) for f in coord]) for coord in sources_out)
+            sources_out = (reversed([convert.format_float(f) for f in coord]) for coord in sources_out)
             params.extend([("from_point", ",".join(coord)) for coord in sources_out])
 
             destinations_out = (
-                reversed([convert._format_float(f) for f in coord]) for coord in destinations_out
+                reversed([convert.format_float(f) for f in coord]) for coord in destinations_out
             )
             params.extend([("to_point", ",".join(coord)) for coord in destinations_out])
 
@@ -606,7 +606,7 @@ class Graphhopper:
                 params.append(("out_array", e))
 
         if debug is not None:
-            params.append(("debug", convert._convert_bool(debug)))
+            params.append(("debug", convert.convert_bool(debug)))
 
         return self._parse_matrix_json(
             self.client._request("/matrix", get_params=params, dry_run=dry_run),

--- a/routingpy/routers/heremaps.py
+++ b/routingpy/routers/heremaps.py
@@ -168,19 +168,19 @@ class HereMaps:
             here_waypoint = ["geo"]
             if self.waypoint_type is not None and self.stopover_duration is not None:
                 here_waypoint.append(
-                    convert._delimit_list([self.waypoint_type, self.stopover_duration], ",")
+                    convert.delimit_list([self.waypoint_type, self.stopover_duration], ",")
                 )
             elif self.waypoint_type is not None:
                 here_waypoint.append(self.waypoint_type)
 
-            position = convert._delimit_list(
-                [convert._format_float(f) for f in list(reversed(self.position))], ","
+            position = convert.delimit_list(
+                [convert.format_float(f) for f in list(reversed(self.position))], ","
             )
             position += ";" + self.transit_radius
             position += ";" + self.user_label
             position += ";" + self.heading
             here_waypoint.append(position)
-            return convert._delimit_list(here_waypoint, "!")
+            return convert.delimit_list(here_waypoint, "!")
 
     class RoutingMode(object):
         """
@@ -229,9 +229,9 @@ class HereMaps:
             if self.features is not None:
                 get_features = []
                 for f, w in self.features.items():
-                    get_features.append(convert._delimit_list([f, str(w)], ":"))
-                routing_mode.append(convert._delimit_list(get_features, ","))
-            return convert._delimit_list(routing_mode, ";")
+                    get_features.append(convert.delimit_list([f, str(w)], ":"))
+                routing_mode.append(convert.delimit_list(get_features, ","))
+            return convert.delimit_list(routing_mode, ";")
 
     def directions(  # noqa: C901
         self,
@@ -609,12 +609,12 @@ class HereMaps:
             params["requestId"] = request_id
 
         if avoid_areas is not None:
-            params["avoidAreas"] = convert._delimit_list(
+            params["avoidAreas"] = convert.delimit_list(
                 [
-                    convert._delimit_list(
+                    convert.delimit_list(
                         [
-                            convert._delimit_list(
-                                [convert._format_float(f) for f in list(reversed(pair))], ","
+                            convert.delimit_list(
+                                [convert.format_float(f) for f in list(reversed(pair))], ","
                             )
                             for pair in bounding_box
                         ],
@@ -626,25 +626,25 @@ class HereMaps:
             )
 
         if avoid_links is not None:
-            params["avoidLinks"] = convert._delimit_list(avoid_links, ",")
+            params["avoidLinks"] = convert.delimit_list(avoid_links, ",")
 
         if avoid_seasonal_closures is not None:
-            params["avoidSeasonalClosures"] = convert._convert_bool(avoid_seasonal_closures)
+            params["avoidSeasonalClosures"] = convert.convert_bool(avoid_seasonal_closures)
 
         if avoid_turns is not None:
             params["avoidTurns"] = avoid_turns
 
         if allowed_zones is not None:
-            params["allowedZones"] = convert._delimit_list(allowed_zones, ",")
+            params["allowedZones"] = convert.delimit_list(allowed_zones, ",")
 
         if exclude_zones is not None:
-            params["excludeZones"] = convert._delimit_list(exclude_zones, ",")
+            params["excludeZones"] = convert.delimit_list(exclude_zones, ",")
 
         if exclude_zone_types is not None:
-            params["excludeZoneTypes"] = convert._delimit_list(exclude_zone_types, ",")
+            params["excludeZoneTypes"] = convert.delimit_list(exclude_zone_types, ",")
 
         if exclude_countries is not None:
-            params["excludeCountries"] = convert._delimit_list(exclude_countries, ",")
+            params["excludeCountries"] = convert.delimit_list(exclude_countries, ",")
 
         if departure is not None:
             params["departure"] = departure
@@ -658,9 +658,9 @@ class HereMaps:
             params["metricSystem"] = metric_system
 
         if view_bounds is not None:
-            params["viewBounds"] = convert._delimit_list(
+            params["viewBounds"] = convert.delimit_list(
                 [
-                    convert._delimit_list([convert._format_float(f) for f in list(reversed(pair))], ",")
+                    convert.delimit_list([convert.format_float(f) for f in list(reversed(pair))], ",")
                     for pair in view_bounds
                 ],
                 ";",
@@ -681,25 +681,25 @@ class HereMaps:
             params["jsonCallback"] = json_callback
 
         if representation is not None:
-            params["representation"] = convert._delimit_list(representation, ",")
+            params["representation"] = convert.delimit_list(representation, ",")
 
         if route_attributes is not None:
-            params["routeAttributes"] = convert._delimit_list(route_attributes, ",")
+            params["routeAttributes"] = convert.delimit_list(route_attributes, ",")
 
         if leg_attributes is not None:
-            params["legAttributes"] = convert._delimit_list(leg_attributes, ",")
+            params["legAttributes"] = convert.delimit_list(leg_attributes, ",")
 
         if maneuver_attributes is not None:
-            params["maneuverAttributes"] = convert._delimit_list(maneuver_attributes, ",")
+            params["maneuverAttributes"] = convert.delimit_list(maneuver_attributes, ",")
 
         if link_attributes is not None:
-            params["linkAttributes"] = convert._delimit_list(link_attributes, ",")
+            params["linkAttributes"] = convert.delimit_list(link_attributes, ",")
 
         if line_attributes is not None:
-            params["lineAttributes"] = convert._delimit_list(line_attributes, ",")
+            params["lineAttributes"] = convert.delimit_list(line_attributes, ",")
 
         if generalization_tolerances is not None:
-            params["generalizationTolerances"] = convert._delimit_list(generalization_tolerances, ",")
+            params["generalizationTolerances"] = convert.delimit_list(generalization_tolerances, ",")
 
         if vehicle_type is not None:
             params["vehicleType"] = vehicle_type
@@ -711,7 +711,7 @@ class HereMaps:
             params["maxNumberOfChanges"] = max_number_of_changes
 
         if avoid_transport_types is not None:
-            params["avoidTransportTypes"] = convert._delimit_list(avoid_transport_types, ",")
+            params["avoidTransportTypes"] = convert.delimit_list(avoid_transport_types, ",")
 
         if walk_time_multiplier is not None:
             params["walkTimeMultiplier"] = walk_time_multiplier
@@ -723,7 +723,7 @@ class HereMaps:
             params["walkRadius"] = walk_radius
 
         if combine_change is not None:
-            params["combineChange"] = convert._convert_bool(combine_change)
+            params["combineChange"] = convert.convert_bool(combine_change)
 
         if truck_type is not None:
             params["truckType"] = truck_type
@@ -732,7 +732,7 @@ class HereMaps:
             params["trailersCount"] = trailers_count
 
         if shipped_hazardous_goods is not None:
-            params["shippedHazardousGoods"] = convert._delimit_list(shipped_hazardous_goods, ",")
+            params["shippedHazardousGoods"] = convert.delimit_list(shipped_hazardous_goods, ",")
 
         if limited_weight is not None:
             params["limitedWeight"] = limited_weight
@@ -750,13 +750,13 @@ class HereMaps:
             params["length"] = length
 
         if tunnel_category is not None:
-            params["tunnelCategory"] = convert._delimit_list(tunnel_category, ",")
+            params["tunnelCategory"] = convert.delimit_list(tunnel_category, ",")
 
         if truck_restriction_penalty is not None:
             params["truckRestrictionPenalty"] = truck_restriction_penalty
 
         if return_elevation is not None:
-            params["returnElevation"] = convert._convert_bool(return_elevation)
+            params["returnElevation"] = convert.convert_bool(return_elevation)
 
         if consumption_model is not None:
             params["consumptionModel"] = consumption_model
@@ -769,7 +769,7 @@ class HereMaps:
 
         return self._parse_direction_json(
             self.client._request(
-                convert._delimit_list(["/calculateroute", format], "."),
+                convert.delimit_list(["/calculateroute", format], "."),
                 get_params=params,
                 dry_run=dry_run,
             ),
@@ -1004,7 +1004,7 @@ class HereMaps:
             params["mode"] = profile.make_routing_mode()
 
         if intervals is not None:
-            params["range"] = convert._delimit_list(intervals, ",")
+            params["range"] = convert.delimit_list(intervals, ",")
 
         if interval_type is not None:
             params["rangeType"] = interval_type
@@ -1015,7 +1015,7 @@ class HereMaps:
             params["arrival"] = arrival
 
         if single_component is not None:
-            params["singleComponent"] = convert._convert_bool(single_component)
+            params["singleComponent"] = convert.convert_bool(single_component)
 
         if max_points is not None:
             params["maxPoints"] = max_points
@@ -1036,7 +1036,7 @@ class HereMaps:
             params["trailersCount"] = trailers_count
 
         if shipped_hazardous_goods is not None:
-            params["shippedHazardousGoods"] = convert._delimit_list(shipped_hazardous_goods, ",")
+            params["shippedHazardousGoods"] = convert.delimit_list(shipped_hazardous_goods, ",")
 
         if limited_weight is not None:
             params["limitedWeight"] = limited_weight
@@ -1054,7 +1054,7 @@ class HereMaps:
             params["length"] = length
 
         if tunnel_category is not None:
-            params["tunnelCategory"] = convert._delimit_list(tunnel_category, ",")
+            params["tunnelCategory"] = convert.delimit_list(tunnel_category, ",")
 
         if consumption_model is not None:
             params["consumptionModel"] = consumption_model
@@ -1067,7 +1067,7 @@ class HereMaps:
 
         return self._parse_isochrone_json(
             self.client._request(
-                convert._delimit_list(["/calculateisoline", format], "."),
+                convert.delimit_list(["/calculateisoline", format], "."),
                 get_params=params,
                 dry_run=dry_run,
             ),
@@ -1291,12 +1291,12 @@ class HereMaps:
             params["searchRange"] = search_range
 
         if avoid_areas is not None:
-            params["avoidAreas"] = convert._delimit_list(
+            params["avoidAreas"] = convert.delimit_list(
                 [
-                    convert._delimit_list(
+                    convert.delimit_list(
                         [
-                            convert._delimit_list(
-                                [convert._format_float(f) for f in list(reversed(pair))], ","
+                            convert.delimit_list(
+                                [convert.format_float(f) for f in list(reversed(pair))], ","
                             )
                             for pair in bounding_box
                         ],
@@ -1308,22 +1308,22 @@ class HereMaps:
             )
 
         if avoid_links is not None:
-            params["avoidLinks"] = convert._delimit_list(avoid_links, ",")
+            params["avoidLinks"] = convert.delimit_list(avoid_links, ",")
 
         if avoid_turns is not None:
             params["avoidTurns"] = avoid_turns
 
         if exclude_countries is not None:
-            params["excludeCountries"] = convert._delimit_list(exclude_countries, ",")
+            params["excludeCountries"] = convert.delimit_list(exclude_countries, ",")
 
         if departure is not None:
             params["departure"] = departure.isoformat()
 
         if matrix_attributes is not None:
-            params["matrixAttributes"] = convert._delimit_list(matrix_attributes, ",")
+            params["matrixAttributes"] = convert.delimit_list(matrix_attributes, ",")
 
         if summary_attributes is not None:
-            params["summaryAttributes"] = convert._delimit_list(summary_attributes, ",")
+            params["summaryAttributes"] = convert.delimit_list(summary_attributes, ",")
 
         if truck_type is not None:
             params["truckType"] = truck_type
@@ -1332,7 +1332,7 @@ class HereMaps:
             params["trailersCount"] = trailers_count
 
         if shipped_hazardous_goods is not None:
-            params["shippedHazardousGoods"] = convert._delimit_list(shipped_hazardous_goods, ",")
+            params["shippedHazardousGoods"] = convert.delimit_list(shipped_hazardous_goods, ",")
 
         if limited_weight is not None:
             params["limitedWeight"] = limited_weight
@@ -1350,14 +1350,14 @@ class HereMaps:
             params["length"] = length
 
         if tunnel_category is not None:
-            params["tunnelCategory"] = convert._delimit_list(tunnel_category, ",")
+            params["tunnelCategory"] = convert.delimit_list(tunnel_category, ",")
 
         if speed_profile is not None:
             params["speedProfile"] = speed_profile
 
         return self._parse_matrix_json(
             self.client._request(
-                convert._delimit_list(["/calculatematrix", format], "."),
+                convert.delimit_list(["/calculatematrix", format], "."),
                 get_params=params,
                 dry_run=dry_run,
             )
@@ -1411,8 +1411,8 @@ class HereMaps:
                 if isinstance(locations, self.Waypoint):
                     locations.append(locations._make_waypoint())
                 elif isinstance(locations, (list, tuple)):
-                    wp = "geo!" + convert._delimit_list(
-                        [convert._format_float(f) for f in list(reversed(coord))], ","
+                    wp = "geo!" + convert.delimit_list(
+                        [convert.format_float(f) for f in list(reversed(coord))], ","
                     )
                     locations.append(wp)
                 else:
@@ -1424,8 +1424,8 @@ class HereMaps:
 
         # Isochrones
         elif isinstance(coordinates[0], float):
-            center = "geo!" + convert._delimit_list(
-                [convert._format_float(f) for f in list(reversed(coordinates))], ","
+            center = "geo!" + convert.delimit_list(
+                [convert.format_float(f) for f in list(reversed(coordinates))], ","
             )
             locations.append(center)
         # Isochrones using waypoint class

--- a/routingpy/routers/mapbox_osrm.py
+++ b/routingpy/routers/mapbox_osrm.py
@@ -221,66 +221,66 @@ class MapboxOSRM:
         :rtype: :class:`routingpy.direction.Direction` or :class:`routingpy.direction.Directions`
         """
 
-        coords = convert._delimit_list(
-            [convert._delimit_list([convert._format_float(f) for f in pair]) for pair in locations], ";"
+        coords = convert.delimit_list(
+            [convert.delimit_list([convert.format_float(f) for f in pair]) for pair in locations], ";"
         )
 
         params = {"coordinates": coords}
 
         if radiuses:
-            params["radiuses"] = convert._delimit_list(radiuses, ";")
+            params["radiuses"] = convert.delimit_list(radiuses, ";")
 
         if bearings:
-            params["bearings"] = convert._delimit_list(
-                [convert._delimit_list(pair) for pair in bearings], ";"
+            params["bearings"] = convert.delimit_list(
+                [convert.delimit_list(pair) for pair in bearings], ";"
             )
 
         if alternatives is not None:
-            params["alternatives"] = convert._convert_bool(alternatives)
+            params["alternatives"] = convert.convert_bool(alternatives)
 
         if steps is not None:
-            params["steps"] = convert._convert_bool(steps)
+            params["steps"] = convert.convert_bool(steps)
 
         if continue_straight is not None:
-            params["continue_straight"] = convert._convert_bool(continue_straight)
+            params["continue_straight"] = convert.convert_bool(continue_straight)
 
         if annotations is not None:
-            params["annotations"] = convert._delimit_list(annotations)
+            params["annotations"] = convert.delimit_list(annotations)
 
         if geometries:
             params["geometries"] = geometries
 
         if overview is not None:
-            params["overview"] = convert._convert_bool(overview)
+            params["overview"] = convert.convert_bool(overview)
 
         if exclude is not None:
             params["exclude"] = exclude
 
         if approaches:
-            params["approaches"] = ";" + convert._delimit_list(approaches, ";")
+            params["approaches"] = ";" + convert.delimit_list(approaches, ";")
 
         if banner_instructions:
-            params["banner_instuctions"] = convert._convert_bool(banner_instructions)
+            params["banner_instuctions"] = convert.convert_bool(banner_instructions)
 
         if language:
             params["language"] = language
 
         if roundabout_exits:
-            params["roundabout_exits"] = convert._convert_bool(roundabout_exits)
+            params["roundabout_exits"] = convert.convert_bool(roundabout_exits)
 
         if voice_instructions:
-            params["voide_instructions"] = convert._convert_bool(voice_instructions)
+            params["voide_instructions"] = convert.convert_bool(voice_instructions)
 
         if voice_units:
             params["voice_units"] = voice_units
 
         if waypoint_names:
-            params["waypoint_names"] = convert._delimit_list(waypoint_names, ";")
+            params["waypoint_names"] = convert.delimit_list(waypoint_names, ";")
 
         if waypoint_targets:
-            params["waypoint_targets"] = ";" + convert._delimit_list(
+            params["waypoint_targets"] = ";" + convert.delimit_list(
                 [
-                    convert._delimit_list([convert._format_float(f) for f in pair])
+                    convert.delimit_list([convert.format_float(f) for f in pair])
                     for pair in waypoint_targets
                 ],
                 ";",
@@ -389,14 +389,14 @@ class MapboxOSRM:
         """
 
         params = {
-            "contours_minutes": convert._delimit_list([int(x / 60) for x in sorted(intervals)], ","),
+            "contours_minutes": convert.delimit_list([int(x / 60) for x in sorted(intervals)], ","),
             "access_token": self.api_key,
         }
 
-        locations_string = convert._delimit_list(locations, ",")
+        locations_string = convert.delimit_list(locations, ",")
 
         if contours_colors:
-            params["contours_colors"] = convert._delimit_list(contours_colors, ",")
+            params["contours_colors"] = convert.delimit_list(contours_colors, ",")
 
         if polygons is not None:
             params["polygons"] = polygons
@@ -483,20 +483,20 @@ class MapboxOSRM:
         :rtype: :class:`routingpy.matrix.Matrix`
         """
 
-        coords = convert._delimit_list(
-            [convert._delimit_list([convert._format_float(f) for f in pair]) for pair in locations], ";"
+        coords = convert.delimit_list(
+            [convert.delimit_list([convert.format_float(f) for f in pair]) for pair in locations], ";"
         )
 
         params = {"access_token": self.api_key}
 
         if sources:
-            params["sources"] = convert._delimit_list(sources, ";")
+            params["sources"] = convert.delimit_list(sources, ";")
 
         if destinations:
-            params["destinations"] = convert._delimit_list(destinations, ";")
+            params["destinations"] = convert.delimit_list(destinations, ";")
 
         if annotations:
-            params["annotations"] = convert._delimit_list(annotations)
+            params["annotations"] = convert.delimit_list(annotations)
 
         if fallback_speed:
             params["fallback_speed"] = str(fallback_speed)

--- a/routingpy/routers/osrm.py
+++ b/routingpy/routers/osrm.py
@@ -158,38 +158,13 @@ class OSRM:
         :returns: One or multiple route(s) from provided coordinates and restrictions.
         :rtype: :class:`routingpy.direction.Direction` or :class:`routingpy.direction.Directions`
         """
-
-        coords = convert._delimit_list(
-            [convert._delimit_list([convert._format_float(f) for f in pair]) for pair in locations], ";"
+        coords = convert.delimit_list(
+            [convert.delimit_list([convert.format_float(f) for f in pair]) for pair in locations], ";"
         )
 
-        params = dict()
-
-        if radiuses:
-            params["radiuses"] = convert._delimit_list(radiuses, ";")
-
-        if bearings:
-            params["bearings"] = convert._delimit_list(
-                [convert._delimit_list(pair) for pair in bearings], ";"
-            )
-
-        if alternatives is not None:
-            params["alternatives"] = convert._convert_bool(alternatives)
-
-        if steps is not None:
-            params["steps"] = convert._convert_bool(steps)
-
-        if continue_straight is not None:
-            params["continue_straight"] = convert._convert_bool(continue_straight)
-
-        if annotations is not None:
-            params["annotations"] = convert._convert_bool(annotations)
-
-        if geometries:
-            params["geometries"] = geometries
-
-        if overview is not None:
-            params["overview"] = convert._convert_bool(overview)
+        params = self._get_direction_params(
+            radiuses, bearings, alternatives, steps, continue_straight, annotations, geometries, overview
+        )
 
         return self._parse_direction_json(
             self.client._request(
@@ -198,6 +173,47 @@ class OSRM:
             alternatives,
             geometries,
         )
+
+    @staticmethod
+    def _get_direction_params(
+        radiuses=None,
+        bearings=None,
+        alternatives=None,
+        steps=None,
+        continue_straight=None,
+        annotations=None,
+        geometries=None,
+        overview=None,
+    ):
+        params = dict()
+
+        if radiuses:
+            params["radiuses"] = convert.delimit_list(radiuses, ";")
+
+        if bearings:
+            params["bearings"] = convert.delimit_list(
+                [convert.delimit_list(pair) for pair in bearings], ";"
+            )
+
+        if alternatives is not None:
+            params["alternatives"] = convert.convert_bool(alternatives)
+
+        if steps is not None:
+            params["steps"] = convert.convert_bool(steps)
+
+        if continue_straight is not None:
+            params["continue_straight"] = convert.convert_bool(continue_straight)
+
+        if annotations is not None:
+            params["annotations"] = convert.convert_bool(annotations)
+
+        if geometries:
+            params["geometries"] = geometries
+
+        if overview is not None:
+            params["overview"] = convert.convert_bool(overview)
+
+        return params
 
     @staticmethod
     def _parse_direction_json(response, alternatives, geometry_format):
@@ -252,7 +268,7 @@ class OSRM:
         sources=None,
         destinations=None,
         dry_run=None,
-        annotations=["duration", "distance"],
+        annotations=("duration", "distance"),
     ):
         """
         Gets travel distance and time for a matrix of origins and destinations.
@@ -306,26 +322,32 @@ class OSRM:
            Add annotations parameter to get both distance and duration
         """
 
-        coords = convert._delimit_list(
-            [convert._delimit_list([convert._format_float(f) for f in pair]) for pair in locations], ";"
+        coords = convert.delimit_list(
+            [convert.delimit_list([convert.format_float(f) for f in pair]) for pair in locations], ";"
         )
 
-        params = dict()
-
-        if sources:
-            params["sources"] = convert._delimit_list(sources, ";")
-
-        if destinations:
-            params["destinations"] = convert._delimit_list(destinations, ";")
-
-        if annotations:
-            params["annotations"] = convert._delimit_list(annotations)
+        params = self._get_matrix_params(sources, destinations, annotations)
 
         return self._parse_matrix_json(
             self.client._request(
                 "/table/v1/" + profile + "/" + coords, get_params=params, dry_run=dry_run
             )
         )
+
+    @staticmethod
+    def _get_matrix_params(sources=None, destinations=None, annotations=("duration", "distance")):
+        params = dict()
+
+        if sources:
+            params["sources"] = convert.delimit_list(sources, ";")
+
+        if destinations:
+            params["destinations"] = convert.delimit_list(destinations, ";")
+
+        if annotations:
+            params["annotations"] = convert.delimit_list(annotations)
+
+        return params
 
     @staticmethod
     def _parse_matrix_json(response):

--- a/routingpy/routers/osrm.py
+++ b/routingpy/routers/osrm.py
@@ -162,7 +162,7 @@ class OSRM:
             [convert.delimit_list([convert.format_float(f) for f in pair]) for pair in locations], ";"
         )
 
-        params = self._get_direction_params(
+        params = self.get_direction_params(
             radiuses, bearings, alternatives, steps, continue_straight, annotations, geometries, overview
         )
 
@@ -175,7 +175,7 @@ class OSRM:
         )
 
     @staticmethod
-    def _get_direction_params(
+    def get_direction_params(
         radiuses=None,
         bearings=None,
         alternatives=None,
@@ -326,7 +326,7 @@ class OSRM:
             [convert.delimit_list([convert.format_float(f) for f in pair]) for pair in locations], ";"
         )
 
-        params = self._get_matrix_params(sources, destinations, annotations)
+        params = self.get_matrix_params(sources, destinations, annotations)
 
         return self._parse_matrix_json(
             self.client._request(
@@ -335,7 +335,7 @@ class OSRM:
         )
 
     @staticmethod
-    def _get_matrix_params(sources=None, destinations=None, annotations=("duration", "distance")):
+    def get_matrix_params(sources=None, destinations=None, annotations=("duration", "distance")):
         params = dict()
 
         if sources:

--- a/routingpy/routers/valhalla.py
+++ b/routingpy/routers/valhalla.py
@@ -192,9 +192,44 @@ class Valhalla:
         :rtype: :class:`routingpy.direction.Direction`
         """
 
+        params = self._get_direction_params(
+            locations,
+            profile,
+            preference,
+            options,
+            units,
+            language,
+            directions_type,
+            avoid_locations,
+            avoid_polygons,
+            date_time,
+            id,
+        )
+
+        get_params = {"access_token": self.api_key} if self.api_key else {}
+
+        return self._parse_direction_json(
+            self.client._request("/route", get_params=get_params, post_params=params, dry_run=dry_run),
+            units,
+        )
+
+    @staticmethod
+    def _get_direction_params(
+        locations,
+        profile,
+        preference=None,
+        options=None,
+        units=None,
+        language=None,
+        directions_type=None,
+        avoid_locations=None,
+        avoid_polygons=None,
+        date_time=None,
+        id=None,
+    ):
         params = dict(costing=profile)
 
-        params["locations"] = self._build_locations(locations)
+        params["locations"] = Valhalla._build_locations(locations)
 
         if options or preference:
             params["costing_options"] = dict()
@@ -215,7 +250,7 @@ class Valhalla:
                 params["directions_options"]["directions_type"] = directions_type
 
         if avoid_locations:
-            params["avoid_locations"] = self._build_locations(avoid_locations)
+            params["avoid_locations"] = Valhalla._build_locations(avoid_locations)
 
         if avoid_polygons:
             params["avoid_polygons"] = avoid_polygons
@@ -226,12 +261,7 @@ class Valhalla:
         if id:
             params["id"] = id
 
-        get_params = {"access_token": self.api_key} if self.api_key else {}
-
-        return self._parse_direction_json(
-            self.client._request("/route", get_params=get_params, post_params=params, dry_run=dry_run),
-            units,
-        )
+        return params
 
     @staticmethod
     def _parse_direction_json(response, units):
@@ -350,8 +380,51 @@ class Valhalla:
         :rtype: :class:`routingpy.isochrone.Isochrones`
         """
 
-        location_objects = self._build_locations(locations)
+        params = self._get_isochrone_params(
+            locations,
+            profile,
+            intervals,
+            interval_type,
+            colors,
+            polygons,
+            denoise,
+            generalize,
+            preference,
+            options,
+            avoid_locations,
+            avoid_polygons,
+            date_time,
+            show_locations,
+            id,
+        )
 
+        get_params = {"access_token": self.api_key} if self.api_key else {}
+        return self._parse_isochrone_json(
+            self.client._request(
+                "/isochrone", get_params=get_params, post_params=params, dry_run=dry_run
+            ),
+            intervals,
+            locations,
+        )
+
+    @staticmethod
+    def _get_isochrone_params(  # noqa: C901
+        locations,
+        profile,
+        intervals,
+        interval_type=None,
+        colors=None,
+        polygons=None,
+        denoise=None,
+        generalize=None,
+        preference=None,
+        options=None,
+        avoid_locations=None,
+        avoid_polygons=None,
+        date_time=None,
+        show_locations=None,
+        id=None,
+    ):
         contours = []
         for idx, r in enumerate(intervals):
             key = "time"
@@ -369,7 +442,7 @@ class Valhalla:
             contours.append(d)
 
         params = {
-            "locations": location_objects,
+            "locations": Valhalla._build_locations(locations),
             "costing": profile,
             "contours": contours,
         }
@@ -393,7 +466,7 @@ class Valhalla:
             params["generalize"] = generalize
 
         if avoid_locations:
-            params["avoid_locations"] = self._build_locations(avoid_locations)
+            params["avoid_locations"] = Valhalla._build_locations(avoid_locations)
 
         if avoid_polygons:
             params["avoid_polygons"] = avoid_polygons
@@ -407,14 +480,7 @@ class Valhalla:
         if id:
             params["id"] = id
 
-        get_params = {"access_token": self.api_key} if self.api_key else {}
-        return self._parse_isochrone_json(
-            self.client._request(
-                "/isochrone", get_params=get_params, post_params=params, dry_run=dry_run
-            ),
-            intervals,
-            locations,
-        )
+        return params
 
     @staticmethod
     def _parse_isochrone_json(response, intervals, locations):
@@ -503,11 +569,46 @@ class Valhalla:
         :rtype: :class:`routingpy.matrix.Matrix`
         """
 
+        params = self._get_matrix_params(
+            locations,
+            profile,
+            sources,
+            destinations,
+            preference,
+            options,
+            avoid_locations,
+            avoid_polygons,
+            units,
+            id,
+        )
+
+        get_params = {"access_token": self.api_key} if self.api_key else {}
+
+        return self._parse_matrix_json(
+            self.client._request(
+                "/sources_to_targets", get_params=get_params, post_params=params, dry_run=dry_run
+            ),
+            units,
+        )
+
+    @staticmethod
+    def _get_matrix_params(
+        locations,
+        profile,
+        sources=None,
+        destinations=None,
+        preference=None,
+        options=None,
+        avoid_locations=None,
+        avoid_polygons=None,
+        units=None,
+        id=None,
+    ):
         params = {
             "costing": profile,
         }
 
-        locations = self._build_locations(locations)
+        locations = Valhalla._build_locations(locations)
 
         sources_coords = locations
         if sources is not None:
@@ -533,7 +634,7 @@ class Valhalla:
                 params["costing_options"][profile]["shortest"] = True
 
         if avoid_locations:
-            params["avoid_locations"] = self._build_locations(avoid_locations)
+            params["avoid_locations"] = Valhalla._build_locations(avoid_locations)
 
         if avoid_polygons:
             params["avoid_polygons"] = avoid_polygons
@@ -544,14 +645,7 @@ class Valhalla:
         if id:
             params["id"] = id
 
-        get_params = {"access_token": self.api_key} if self.api_key else {}
-
-        return self._parse_matrix_json(
-            self.client._request(
-                "/sources_to_targets", get_params=get_params, post_params=params, dry_run=dry_run
-            ),
-            units,
-        )
+        return params
 
     @staticmethod
     def _parse_matrix_json(response, units):
@@ -569,17 +663,18 @@ class Valhalla:
 
         return Matrix(durations=durations, distances=distances, raw=response)
 
-    def _build_locations(self, coordinates):
+    @staticmethod
+    def _build_locations(coordinates):
         """Build the locations object for all methods"""
 
         locations = []
 
         # Isochrones only support one coordinate tuple, so check for type of first element
-        if isinstance(coordinates[0], (list, tuple, self.Waypoint)):
+        if isinstance(coordinates[0], (list, tuple, Valhalla.Waypoint)):
             for idx, coord in enumerate(coordinates):
                 if isinstance(coord, (list, tuple)):
                     locations.append({"lon": coord[0], "lat": coord[1]}),
-                elif isinstance(coord, self.Waypoint):
+                elif isinstance(coord, Valhalla.Waypoint):
                     locations.append(coord._make_waypoint())
                 else:
                     raise TypeError(

--- a/routingpy/routers/valhalla.py
+++ b/routingpy/routers/valhalla.py
@@ -192,7 +192,7 @@ class Valhalla:
         :rtype: :class:`routingpy.direction.Direction`
         """
 
-        params = self._get_direction_params(
+        params = self.get_direction_params(
             locations,
             profile,
             preference,
@@ -214,7 +214,7 @@ class Valhalla:
         )
 
     @staticmethod
-    def _get_direction_params(
+    def get_direction_params(
         locations,
         profile,
         preference=None,
@@ -380,7 +380,7 @@ class Valhalla:
         :rtype: :class:`routingpy.isochrone.Isochrones`
         """
 
-        params = self._get_isochrone_params(
+        params = self.get_isochrone_params(
             locations,
             profile,
             intervals,
@@ -408,7 +408,7 @@ class Valhalla:
         )
 
     @staticmethod
-    def _get_isochrone_params(  # noqa: C901
+    def get_isochrone_params(  # noqa: C901
         locations,
         profile,
         intervals,
@@ -569,7 +569,7 @@ class Valhalla:
         :rtype: :class:`routingpy.matrix.Matrix`
         """
 
-        params = self._get_matrix_params(
+        params = self.get_matrix_params(
             locations,
             profile,
             sources,
@@ -592,7 +592,7 @@ class Valhalla:
         )
 
     @staticmethod
-    def _get_matrix_params(
+    def get_matrix_params(
         locations,
         profile,
         sources=None,

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -24,7 +24,7 @@ class UtilsTest(_test.TestCase):  # noqa: E741
     def test_delimit_list(self):
 
         l = [(8.68864, 49.42058), (8.68092, 49.41578)]  # noqa: E741
-        s = convert._delimit_list([convert._delimit_list(pair, ",") for pair in l], "|")
+        s = convert.delimit_list([convert.delimit_list(pair, ",") for pair in l], "|")
         self.assertEqual(s, "8.68864,49.42058|8.68092,49.41578")
 
     def test_delimit_list_error(self):
@@ -32,4 +32,4 @@ class UtilsTest(_test.TestCase):  # noqa: E741
         falses = ["8", 8, {"a": "b", 3: "a", 4: 4}]
         for f in falses:
             with self.assertRaises(TypeError):
-                convert._delimit_list(f)
+                convert.delimit_list(f)

--- a/tests/test_mapbox_osrm.py
+++ b/tests/test_mapbox_osrm.py
@@ -117,7 +117,7 @@ class MapboxOSRMTest(_test.TestCase):
             responses.GET,
             "https://api.mapbox.com/isochrone/v1/mapbox/{}/{}".format(
                 query["profile"],
-                convert._delimit_list(query["locations"]),
+                convert.delimit_list(query["locations"]),
             ),
             status=200,
             json=ENDPOINTS_RESPONSES[self.name]["isochrones"],
@@ -143,7 +143,7 @@ class MapboxOSRMTest(_test.TestCase):
     @responses.activate
     def test_full_matrix(self):
         query = ENDPOINTS_QUERIES[self.name]["matrix"]
-        coords = convert._delimit_list([convert._delimit_list(pair) for pair in query["locations"]], ";")
+        coords = convert.delimit_list([convert.delimit_list(pair) for pair in query["locations"]], ";")
 
         responses.add(
             responses.GET,
@@ -169,7 +169,7 @@ class MapboxOSRMTest(_test.TestCase):
     @responses.activate
     def test_few_sources_destinations_matrix(self):
         query = deepcopy(ENDPOINTS_QUERIES[self.name]["matrix"])
-        coords = convert._delimit_list([convert._delimit_list(pair) for pair in query["locations"]], ";")
+        coords = convert.delimit_list([convert.delimit_list(pair) for pair in query["locations"]], ";")
 
         query["sources"] = [1, 2]
         query["destinations"] = [0, 2]

--- a/tests/test_osrm.py
+++ b/tests/test_osrm.py
@@ -37,7 +37,7 @@ class OSRMTest(_test.TestCase):
     def test_full_directions(self):
         query = deepcopy(ENDPOINTS_QUERIES[self.name]["directions"])
         query["alternatives"] = False
-        coords = convert._delimit_list([convert._delimit_list(pair) for pair in query["locations"]], ";")
+        coords = convert.delimit_list([convert.delimit_list(pair) for pair in query["locations"]], ";")
 
         responses.add(
             responses.GET,
@@ -64,7 +64,7 @@ class OSRMTest(_test.TestCase):
     @responses.activate
     def test_full_directions_alternatives(self):
         query = ENDPOINTS_QUERIES[self.name]["directions"]
-        coords = convert._delimit_list([convert._delimit_list(pair) for pair in query["locations"]], ";")
+        coords = convert.delimit_list([convert.delimit_list(pair) for pair in query["locations"]], ";")
 
         responses.add(
             responses.GET,
@@ -95,7 +95,7 @@ class OSRMTest(_test.TestCase):
     def test_directions_polyline5(self):
         query = deepcopy(ENDPOINTS_QUERIES[self.name]["directions"])
         query["geometries"] = "polyline"
-        coords = convert._delimit_list([convert._delimit_list(pair) for pair in query["locations"]], ";")
+        coords = convert.delimit_list([convert.delimit_list(pair) for pair in query["locations"]], ";")
 
         responses.add(
             responses.GET,
@@ -160,7 +160,7 @@ class OSRMTest(_test.TestCase):
     def test_directions_polyline6(self):
         query = deepcopy(ENDPOINTS_QUERIES[self.name]["directions"])
         query["geometries"] = "polyline6"
-        coords = convert._delimit_list([convert._delimit_list(pair) for pair in query["locations"]], ";")
+        coords = convert.delimit_list([convert.delimit_list(pair) for pair in query["locations"]], ";")
 
         responses.add(
             responses.GET,
@@ -224,7 +224,7 @@ class OSRMTest(_test.TestCase):
     @responses.activate
     def test_full_matrix(self):
         query = ENDPOINTS_QUERIES[self.name]["matrix"]
-        coords = convert._delimit_list([convert._delimit_list(pair) for pair in query["locations"]], ";")
+        coords = convert.delimit_list([convert.delimit_list(pair) for pair in query["locations"]], ";")
 
         responses.add(
             responses.GET,
@@ -250,7 +250,7 @@ class OSRMTest(_test.TestCase):
     @responses.activate
     def test_few_sources_destinations_matrix(self):
         query = deepcopy(ENDPOINTS_QUERIES[self.name]["matrix"])
-        coords = convert._delimit_list([convert._delimit_list(pair) for pair in query["locations"]], ";")
+        coords = convert.delimit_list([convert.delimit_list(pair) for pair in query["locations"]], ";")
 
         query["sources"] = [1, 2]
         query["destinations"] = [0, 2]


### PR DESCRIPTION
I only changed valhalla & osrm, as those two are the only ones we can use via python bindings in downstream projects. it's pretty mechanical changes anyways