### PR TITLE
add kwargs to GraphHopper methods

### DIFF
--- a/routingpy/routers/graphhopper.py
+++ b/routingpy/routers/graphhopper.py
@@ -128,8 +128,11 @@ class Graphhopper:
         snap_prevention=None,
         curb_side=None,
         turn_costs=None,
+        **direction_kwargs
     ):
         """Get directions between an origin point and a destination point.
+
+        Use ``direction_kwargs`` for any missing ``directions`` request options.
 
         For more information, visit https://docs.graphhopper.com/#tag/Routing-API/paths/~1route/get.
 
@@ -372,6 +375,8 @@ class Graphhopper:
                         ("alternative_route_max_share_factor", alternative_route_max_share_factor)
                     )
 
+        params.extend(direction_kwargs.items())
+
         return self._parse_directions_json(
             self.client._request("/route", get_params=params, dry_run=dry_run), algorithm, elevation
         )
@@ -417,10 +422,13 @@ class Graphhopper:
         reverse_flow=None,
         debug=None,
         dry_run=None,
+        **isochrones_kwargs
     ):
         """Gets isochrones or equidistants for a range of time/distance values around a given set of coordinates.
 
-        For mroe details visit https://docs.graphhopper.com/#tag/Isochrone-API.
+        Use ``isochrones_kwargs`` for missing ``isochrones`` request options.
+
+        For more details visit https://docs.graphhopper.com/#tag/Isochrone-API.
 
         :param locations: One coordinate pair denoting the location.
         :type locations: tuple of float or list of float
@@ -484,6 +492,8 @@ class Graphhopper:
         if debug is not None:
             params.append(("debug", convert.convert_bool(debug)))
 
+        params.extend(isochrones_kwargs.items())
+
         return self._parse_isochrone_json(
             self.client._request("/isochrone", get_params=params, dry_run=dry_run),
             type,
@@ -521,12 +531,15 @@ class Graphhopper:
         out_array=["times", "distances"],
         debug=None,
         dry_run=None,
+        **matrix_kwargs
     ):
         """Gets travel distance and time for a matrix of origins and destinations.
 
+        Use ``matrix_kwargs`` for any missing ``matrix`` request options.
+
         For more details visit https://docs.graphhopper.com/#tag/Matrix-API.
 
-        :param locations: Specifiy multiple points for which the weight-, route-, time- or distance-matrix should be calculated.
+        :param locations: Specify multiple points for which the weight-, route-, time- or distance-matrix should be calculated.
             In this case the starts are identical to the destinations.
             If there are N points, then NxN entries will be calculated.
             The order of the point parameter is important. Specify at least three points.
@@ -606,6 +619,8 @@ class Graphhopper:
 
         if debug is not None:
             params.append(("debug", convert.convert_bool(debug)))
+
+        params.extend(matrix_kwargs.items())
 
         return self._parse_matrix_json(
             self.client._request("/matrix", get_params=params, dry_run=dry_run),

--- a/tests/test_graphhopper.py
+++ b/tests/test_graphhopper.py
@@ -39,6 +39,7 @@ class GraphhopperTest(_test.TestCase):
     def test_full_directions(self):
         query = deepcopy(ENDPOINTS_QUERIES[self.name]["directions"])
         query["algorithm"] = None
+        query["fake_option"] = 42
 
         responses.add(
             responses.GET,
@@ -56,7 +57,7 @@ class GraphhopperTest(_test.TestCase):
             "elevation=true&heading=50%2C50%2C50&heading_penalty=100&instructions=false&key=sample_key&locale=en&"
             "optimize=true&pass_through=true&point=49.415776%2C8.680916&point=49.420577%2C8.688641&"
             "point=49.445776%2C8.780916&point_hint=Graphhopper%20Lane&point_hint=OSM%20Street&point_hint=Routing%20Broadway&"
-            "&points_encoded=true&vehicle=car&type=json&weighting=short_fastest&snap_prevention=trunk%2Cferry&curb_side=any%2Cright&turn_costs=true",
+            "&points_encoded=true&vehicle=car&type=json&weighting=short_fastest&snap_prevention=trunk%2Cferry&curb_side=any%2Cright&turn_costs=true&fake_option=42",
             responses.calls[0].request.url,
         )
 
@@ -103,6 +104,7 @@ class GraphhopperTest(_test.TestCase):
     def test_full_isochrones(self):
         query = deepcopy(ENDPOINTS_QUERIES[self.name]["isochrones"])
         query["buckets"] = 3
+        query["fake_option"] = 42
 
         responses.add(
             responses.GET,
@@ -116,7 +118,7 @@ class GraphhopperTest(_test.TestCase):
         self.assertEqual(1, len(responses.calls))
         self.assertURLEqual(
             "https://graphhopper.com/api/1/isochrone?buckets=3&debug=false&key=sample_key&"
-            "point=48.23424%2C8.34234&vehicle=car&reverse_flow=true&time_limit=1000&type=json",
+            "point=48.23424%2C8.34234&vehicle=car&reverse_flow=true&time_limit=1000&type=json&fake_option=42",
             responses.calls[0].request.url,
         )
 
@@ -132,6 +134,7 @@ class GraphhopperTest(_test.TestCase):
     @responses.activate
     def test_full_matrix(self):
         query = ENDPOINTS_QUERIES[self.name]["matrix"]
+        query["fake_option"] = 42
 
         responses.add(
             responses.GET,
@@ -145,7 +148,7 @@ class GraphhopperTest(_test.TestCase):
         self.assertEqual(1, len(responses.calls))
         self.assertURLEqual(
             "https://graphhopper.com/api/1/matrix?key=sample_key&out_array=distances&out_array=times&out_array=weights&"
-            "point=49.415776%2C8.680916&point=49.420577%2C8.688641&point=49.445776%2C8.780916&vehicle=car&debug=true",
+            "point=49.415776%2C8.680916&point=49.420577%2C8.688641&point=49.445776%2C8.780916&vehicle=car&debug=true&fake_option=42",
             responses.calls[0].request.url,
         )
 


### PR DESCRIPTION
PR implements partially #42 

I came to an issue with the impossibility of passing an additional but required option for PT routing (on the self-hosted GraphHopper instance). I came to the conclusion that #42  should solve the issue. 

This PR supplies the **kwargs to the GraphHopper methods. the implementation follows the approach in #49 