### PR TITLE
fix here provider, handling failed routes

### DIFF
--- a/routingpy/routers/heremaps.py
+++ b/routingpy/routers/heremaps.py
@@ -24,6 +24,8 @@ from ..matrix import Matrix
 
 from operator import itemgetter
 
+from ..utils import logger
+
 
 class HereMaps:
     """Performs requests to the HERE Maps API services."""
@@ -1394,6 +1396,13 @@ class HereMaps:
         for index, obj in enumerate(mtx_objects):
             if index < (length - 1):
                 next_ = mtx_objects[index + 1]
+            if "summary" not in obj:
+                logger.warn(
+                    "HERE matrix couldn't compute route for %s => %s",
+                    obj["startIndex"],
+                    obj["destinationIndex"],
+                )
+                obj["summary"] = {"travelTime": None, "distance": None}
 
             if "travelTime" in obj["summary"]:
                 index_durations.append(obj["summary"]["travelTime"])

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -465,6 +465,7 @@ ENDPOINTS_RESPONSES = {
                         "destinationIndex": 0,
                         "summary": {"distance": 1188, "travelTime": 69, "costFactor": 69},
                     },
+                    {"startIndex": 1, "destinationIndex": 0, "status": "failed"},
                 ]
             }
         },


### PR DESCRIPTION
There are cases when here can't compute routes between points. And summary field is missing

`The summary is included in the response only if route calculation succeeds.`

https://developer.here.com/documentation/routing/dev_guide/topics/resource-type-route-matrix-entry.html

This causes KeyError

```
>           if "travelTime" in obj["summary"]:
E           KeyError: 'summary'
```