### PR TITLE
Prevent ci run on every push to PR branch 

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -6,14 +6,13 @@ on:
       - master
     paths-ignore:
       - '*.md'
-  pull_request:
-    branches:
-      - master
-    paths-ignore:
-      - '*.md'
+  workflow_dispatch:
+  pull_request_review:
+    types: [submitted]
 
 jobs:
   build:
+    if: github.event.review.state == 'approved' ||  github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-20.04
     strategy:
       matrix:


### PR DESCRIPTION
Basically adjusted the CI tests workflow to mirror the NA QGIS plugin test workflow behavior: run only when a PR has been approved, and be able to dispatch CI runs when needed.
