### PR TITLE
Replace absolute imports

### DIFF
--- a/routingpy/optimization.py
+++ b/routingpy/optimization.py
@@ -16,7 +16,7 @@
 #
 from typing import List, Optional
 
-from routingpy.utils import _ReprMixin, _short_list_repr, decode_polyline5
+from .utils import _ReprMixin, _short_list_repr, decode_polyline5
 
 
 class Job(_ReprMixin):

--- a/routingpy/routers/vroom.py
+++ b/routingpy/routers/vroom.py
@@ -16,9 +16,9 @@
 #
 from typing import List, Optional, Type, Union
 
-from routingpy.client_base import DEFAULT, BaseClient
-from routingpy.client_default import Client
-from routingpy.optimization import Job, Optimization, Route, Shipment, Summary, Unassigned, Vehicle
+from ..client_base import DEFAULT, BaseClient
+from ..client_default import Client
+from ..optimization import Job, Optimization, Route, Shipment, Summary, Unassigned, Vehicle
 
 
 class Vroom:

--- a/routingpy/valhalla_attributes.py
+++ b/routingpy/valhalla_attributes.py
@@ -20,7 +20,7 @@
 from enum import Enum
 from typing import List, Optional, Tuple, Union
 
-from routingpy.utils import decode_polyline6
+from .utils import decode_polyline6
 
 
 class MatchDiscontinuity(str, Enum):


### PR DESCRIPTION
We currently require routingpy as a [git submodule](https://git-scm.com/book/en/v2/Git-Tools-Submodules) in another project, which is why we need to replace all absolute imports  (e.g. `from routingpy.routers import *`) with relative ones.
